### PR TITLE
Remove nonexistant build children stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ workflows:
              branches:
                only: 
                  - master
-      - build_children:
-          context: circle-api
-          requires:
-            - publish_latest
 
 version: 2
 jobs:


### PR DESCRIPTION
Removed build_children stage from circleci, monolithic has no children
at present

Resolves #2